### PR TITLE
Fixed alignment issues

### DIFF
--- a/vita_loader.py
+++ b/vita_loader.py
@@ -13,7 +13,7 @@ import threading
 import struct
 import yaml
 import os
-import binaryninja
+
 class VitaElf():
 
     def __init__(self, bv: BinaryView):
@@ -502,7 +502,7 @@ def sweep_before_load(bv):
             log_info("ran {i} linear sweeps, potentially more functions undiscovered")
 
         #Switch back to main UI event thread and run plugin
-        binaryninja.execute_on_main_thread(lambda: VitaElf(bv).load_vita_symbols())
+        execute_on_main_thread(lambda: VitaElf(bv).load_vita_symbols())
 
     #Run linear sweep analysis in new thread.
     threading.Thread(target=n_linearsweep).start()


### PR DESCRIPTION
Fixed alignment issues stemming from loading symbols during linear sweep by forcing n iterations of linsweep before plugin is loaded. temp fix for odd off-by-one alignment issue in NONAME module export.

We cannot call `bv.update_analysis_and_wait()` on the main UI thread.
    Until a more clever approach is realized, we are now starting a thread that will run linear sweep for `n_max` iterations OR until no more functions are found/created before the plugin is properly loaded. This solves two issues:
1. Loading the plugin and injecting symbols during the initial linear sweep causes mis-alignment issues.
2. There appears to be an issue with binaries using mixed arm & thumb instruction sets. In all binaries tested, the first Linear Sweep run does okay but misses many functions(typically on the order of a few thousand). The second run further resolves mis-identified inline data blocks as instructions/functions and the third will find and create all of them, with the caveat that some actual inline data will be interpreted as instructions, causing a very small amount of non-functions(data) to be represented as mis-aligned instructions.


Need to explore why off-by-one (byte) is occurring in NONAME `module_start` export as this is directly read in from the proper `(Elf32_Addr)addtable` value in the `scelibent_prx2arm struct`. This address was grabbed and cross checked with a hexdump on various test binaries, all revealing the off-by-one located at struct.unpack("I",read(entry_table_addr,4). This causes a bad alignment issue, as all instructions after are shifted by one, thus resulting in wrong/bad instructions.