### PR TITLE
Adding structs for each imported module, stub, and entry.

### DIFF
--- a/structs.py
+++ b/structs.py
@@ -1,0 +1,113 @@
+from binaryninja import BinaryView, StructureBuilder, Type, log_info
+
+# Slightly hacky approach but works well for now. Maps PyStruct fmt string to Binary Ninja Types
+def get_bn_type_from_format(fmt):
+    bn_struct_map = {
+        'H': Type.int(2, False),  # Unsigned short
+        '2s': Type.array(Type.char(), 2),
+        '4s': Type.array(Type.char(), 4),
+        '26s': Type.array(Type.char(), 26),
+        'B': Type.char(),         # Unsigned char
+        'I': Type.int(4, False)   # Unsigned int
+    }
+    return bn_struct_map.get(fmt, Type.void())
+
+def make_bn_struct(fmt, var_names):
+    struct = StructureBuilder.create()
+    offset = 0
+    fmt_pairs = zip(fmt.split(), var_names)
+
+    for f, var in fmt_pairs:
+        bn_type = get_bn_type_from_format(f)
+        struct.insert(offset, bn_type, var)
+        offset += bn_type.width
+
+    return struct
+
+
+
+
+#Common datatypes:
+def create_struct(bv: BinaryView, bn_type: str, addr: int):
+    if bn_type == "SceLibEnt_prx2arm":
+    # Add structs to bn datatypes
+        struct_fmt = "B B H H H H H B B B B I I I I"
+        struct_vars = [
+            "structsize", "reserved1", "version", "attribute", "nfunc",
+            "nvar", "ntlsvar", "hashinfo", "hashinfotls", "reserved2",
+            "nidaltsets", "libname_nid", "libname", "nidtable", "addtable"
+        ]
+        scelibent_dt = make_bn_struct(struct_fmt, struct_vars)
+        bv.define_user_type("SceLibEnt_prx2arm", Type.structure_type(scelibent_dt))
+
+        #Remove any mis-interpreted instructions(functions) at data_addr
+        try:
+            rem_func = bv.get_functions_containing(addr)
+            bv.remove_function(rem_func[0])
+        except:
+            log_info("No function at SceLibEnt_prx2arm location")
+        scelibent_type = bv.get_type_by_name("SceLibEnt_prx2arm")
+        bv.define_data_var(addr=addr,var_type=scelibent_type)
+
+    elif bn_type == "SceLibStub_prx2arm":
+        struct_fmt = "B B H H H H H 4s I I I I I I I I I"
+        struct_vars = [
+            "structsize", "reserved1", "version", "attribute", "nfunc",
+            "nvar", "ntlsvar", "reserved2", "libname_nid", "libname",
+            "sce_sdk_version", "func_nidtable", "func_table", "var_nidtable",
+            "var_table", "tls_nidtable", "tls_table"
+        ]
+        scelibstub_dt = make_bn_struct(struct_fmt, struct_vars)
+        bv.define_user_type("SceLibStub_prx2arm", Type.structure_type(scelibstub_dt))
+
+        #Remove any mis-interpreted instructions(functions) at data_addr
+        try:
+            rem_func = bv.get_functions_containing(addr)
+            bv.remove_function(rem_func[0])
+        except:
+            log_info("No function at SceLibStub_prx2arm location")
+        scelibstub_type = bv.get_type_by_name("SceLibStub_prx2arm")
+        bv.define_data_var(addr=addr,var_type=scelibstub_type)
+
+    elif bn_type == "SceModuleInfo_prx2arm":
+        struct_fmt = "H 2s 26s B B I I I I I I I I I I I I I I I"
+        struct_vars = [
+            "modattribute", "modversion", "modname", "terminal", "infoversion",
+            "resreve", "ent_top", "ent_end", "stub_top", "stub_end",
+            "dbg_fingerprint", "tls_top", "tls_filesz", "tls_memsz",
+            "start_entry", "stop_entry", "arm_exidx_top", "arm_exidx_end",
+            "arm_extab_top", "arm_extab_end"
+        ]
+        scemodinfo_dt = make_bn_struct(struct_fmt, struct_vars)
+        bv.define_user_type("SceModuleInfo_prx2arm", Type.structure_type(scemodinfo_dt))
+
+        #Remove any mis-interpreted instructions(functions) at data_addr
+        try:
+            rem_func = bv.get_functions_containing(addr)
+            bv.remove_function(rem_func[0])
+        except:
+            log_info("No function at SceModuleInfo_prx2arm location")
+        scemodinfo_type = bv.get_type_by_name("SceModuleInfo_prx2arm")
+        bv.define_data_var(addr=addr,var_type=scemodinfo_type)
+
+    #This one is a bit tricky as size varies between 0x20 on FW 0.895, 0x2C on FW 0.931.010, 0x30 on FW 0.945, 0x34 on FW 3.60. We take on the 0x30 default for the time being, tiny errors don't really matter here but TODO: Get size first.
+    elif bn_type == "SceProcessParam":
+        struct_fmt = "I 4s I I I I I I I I I I"
+        struct_vars = [
+            "size", "magic", "version", "sdk_version", "*sceUserMainThreadName",
+            "sceUserMainThreadPriority", "sceUserMainThreadStackSize", "sceUserMainThreadAttribute",
+            "*sceProcessName", "sce_process_preload_disabled", "sceUserMainThreadCpuAffinityMask",
+            "*sce_libcparam"#, "unk_0x30"
+        ]
+        sceprocparam_dt = make_bn_struct(struct_fmt, struct_vars)
+        bv.define_user_type("SceProcessParam", Type.structure_type(sceprocparam_dt))
+
+        #Remove any mis-interpreted instructions(functions) at data_addr
+        try:
+            rem_func = bv.get_functions_containing(addr)
+            bv.remove_function(rem_func[0])
+        except:
+            log_info("No function at SceProcessParam location")
+        sceprocparam_type = bv.get_type_by_name("SceProcessParam")
+        bv.define_data_var(addr=addr,var_type=sceprocparam_type)
+

--- a/vita_loader.py
+++ b/vita_loader.py
@@ -13,6 +13,7 @@ import threading
 import struct
 import yaml
 import os
+import structs
 
 class VitaElf():
 
@@ -31,7 +32,7 @@ class VitaElf():
             self.load_nid_database()
             self.process_exports(self.bv)
             self.process_imports(self.bv)
-
+            self.clean_data_segs()
             log_info("Symbols added successfully.")
 
         except Exception as e:
@@ -88,6 +89,7 @@ class VitaElf():
             ph_struct = self.struct_endianness + "IIIIIIII"
             ph = struct.unpack(ph_struct, ph_data)
             self.program_headers.append(ph)
+        self.base_addr = self.program_headers[0][2]
 
 
     def parse_sce_module_info(self):
@@ -108,7 +110,7 @@ class VitaElf():
             log_error("Invalid SceModuleInfo struct.")
             return None
 
-        #unpacking SceModuleInfo, expanded for easier format character mapping 
+        #unpacking SceModuleInfo, expanded for easier format character mapping
         module_info_struct = self.struct_endianness + (
             "H"    # unsigned short modattribute
             "2s"   # unsigned char modversion[2]
@@ -136,7 +138,7 @@ class VitaElf():
         (
             self.attributes,    # short modattribute
             self.version,       # char modversion[2]
-            name_bytes,         # char modname[26]
+            modname,            # char modname[26]
             self.type,          # char terminal
             self.gp_value,      # char infoversion
             self.resreve,       # Elf32_Addr resreve
@@ -156,9 +158,15 @@ class VitaElf():
             self.extab_end,     # Elf32_Addr arm_extab_end
         ) = SceModuleInfo_unpacked
 
-        self.module_name = name_bytes.partition(b'\x00')[0].decode('ascii', errors='ignore')
+        self.modname = modname.partition(b'\x00')[0].decode('ascii', errors='ignore')
         self.version = [b for b in self.version]  # Convert version from bytes to list of integers
-        log_info(f"Extracted {self.module_name}, version: {self.version}")
+
+
+
+
+
+
+
 
 
     def get_module_info_offset(self):
@@ -222,8 +230,8 @@ class VitaElf():
 
 
         while exports_offset < exports_end:
-            #Is there even a point of making export size dynamic? Unless we split out _scelibent_ppu_common of size 0x10, could be useful to leave flexibility for potential future integration of scelibent_psp and other PRX1 variants. 
-            export_size_data = self.raw.read(exports_offset, 0x20) 
+            #Is there even a point of making export size dynamic? Unless we split out _scelibent_ppu_common of size 0x10, could be useful to leave flexibility for potential future integration of scelibent_psp and other PRX1 variants.
+            export_size_data = self.raw.read(exports_offset, 0x20)
             if len(export_size_data) < 0x20:
                 log_error(f"Incomplete export size data at 0x{exports_offset:X}")
                 break
@@ -234,7 +242,7 @@ class VitaElf():
             if len(export_data) < export_size:
                 log_error(f"Incomplete export data at 0x{exports_offset:X}")
                 break
-            export_struct = self.struct_endianness + "B1BHHHHHBBBBIIII"
+            export_struct = self.struct_endianness + "BBHHHHHBBBBIIII"
             if len(export_data) < struct.calcsize(export_struct):
                 log_error(f"Incomplete export structure at 0x{exports_offset:X}")
                 break
@@ -256,6 +264,12 @@ class VitaElf():
                 nid_table_addr,     #Elf32_Addr nidtable;
                 entry_table_addr,   #Elf32_Addr addtable;
             ) = export_struct
+
+            log_info(f"export_struct: {export_struct}")
+            # Add structs to bn datatypes
+            abs_addr = self.base_addr + exports_offset - ph_offset
+            structs.create_struct(self.bv, "SceLibEnt_prx2arm", abs_addr)
+
 
             if attribute == 0x8000 and library_name_addr == 0:
                 library_name = "NONAME" #NONAME EXPORT,see: wiki.henkaku.xyz/vita/PRX#NONAME_exports
@@ -295,12 +309,15 @@ class VitaElf():
                 if library_name == "NONAME":
                     if variable_nid == 0x6C2224BA:
                         variable_name = "module_info"
+                        structs.create_struct(self.bv, "SceModuleInfo_prx2arm", variable_addr)
                     elif variable_nid == 0x70FBA1E7:
                         variable_name = "module_proc_param"
+                        structs.create_struct(self.bv, "SceProcessParam", variable_addr)
                 else:
                     variable_name = self.lookup_nid_variable(library_nid, variable_nid, library_name)
-                log_info(f"export var: {variable_name}") #TODO
-                self.add_data_symbol(bv, variable_addr, variable_name)
+                    self.add_data_symbol(bv, variable_addr, variable_name)
+                log_info(f"export var: {variable_name} - var addr: {hex(variable_addr)}") #TODO
+
 
             exports_offset += size
 
@@ -315,10 +332,8 @@ class VitaElf():
 
 
         while imports_offset < imports_end:
-            log_info(f"imports_offset: {hex(imports_offset)}") #TODO debug
-
             import_size_data = self.raw.read(imports_offset, 0x34) #Need to get scemodimport version, hardcoded for now.
-            log_info(f"import_size_data: {import_size_data}") #TODO need to actually use this to get size to determine _scelibstub_prx2arm(0x34) or _scelibstub_prx2arm_new(0x24)
+            #TODO need to actually use this to get size to determine _scelibstub_prx2arm(0x34) or _scelibstub_prx2arm_new(0x24)
             if len(import_size_data) < 2:
                 log_error(f"Incomplete import size data at 0x{imports_offset:X}")
                 break
@@ -352,7 +367,7 @@ class VitaElf():
                 # _scelibstub_prx2arm - see wiki.henkaku.xyz/vita/PRX#Imports
                 (
                     size,                   # unsigned char structsize
-                    reserved1,               # unsigned char reserved1
+                    reserved1,              # unsigned char reserved1
                     version,                # unsigned short version
                     attribute,              # unsigned short attribute
                     num_functions,          # unsigned short nfunc
@@ -369,6 +384,10 @@ class VitaElf():
                     tls_nid_table_addr,     # Elf32_Addr tls_nidtable
                     tls_entry_table_addr,   # Elf32_Addr tls_table
                 ) = import_values
+                # Add structs to bn datatypes
+
+                abs_addr = self.base_addr + imports_offset - ph_offset
+                structs.create_struct(self.bv, "SceLibStub_prx2arm", abs_addr)
             else:
                 # _scelibstub_prx2arm_new
                 (
@@ -385,6 +404,7 @@ class VitaElf():
                     var_entry_table_addr,   # Elf32_Addr var_table
                     # Missing fields TODO: This is wrong. fix struct according to wiki.henkaku.xyz/vita/PRX#Imports
                 ) = import_values
+
 
             #get lib name
             library_name = self.read_string_at(bv, library_name_addr)
@@ -412,12 +432,14 @@ class VitaElf():
                 if len(nid_data) < 4 or len(entry_data) < 4:
                     continue
                 variable_nid = struct.unpack("<I", nid_data)[0]
-                variable_stub_addr = struct.unpack("<I", entry_data)[0]
+                variable_addr = struct.unpack("<I", entry_data)[0]
                 variable_name = self.lookup_nid_variable(library_nid, variable_nid, library_name)
-                log_info(f"importing var: {variable_name}") #TODO
-                self.add_data_symbol(bv, variable_stub_addr, variable_name)
+                log_info(f"importing var: {variable_name} - var addr: {variable_addr}") #TODO
+                self.add_data_symbol(bv, variable_addr, variable_name)
 
             imports_offset += size
+
+
 
     def lookup_nid_function(self, library_nid, function_nid, library_name):
     #look up function name using nid db - TODO: Figure out more efficient way, nested nightmare
@@ -450,25 +472,31 @@ class VitaElf():
     def add_function_symbol(self, bv: BinaryView, addr: int, name: str):
         if not bv.get_function_at(addr):
             bv.create_user_function(addr)
-        
+
         #Setting imports to void and tell binary ninja to resolve variables.
         func_type = Type.function(Type.void(), [], variable_arguments=True)
-        
+
         #Get the function pointer
         func = bv.get_function_at(addr)
-        
+
         #set type to void with variables
         func.type = func_type
-        
+
         symbol = Symbol(SymbolType.ImportedFunctionSymbol, addr, name)
-        
+
         #define as import, will need to add check for export but it appears to just be a color coding thing for our purposes.
         bv.define_imported_function(symbol, func)
 
     def add_data_symbol(self, bv: BinaryView, addr: int, name: str):
         symbol = Symbol(SymbolType.DataSymbol, addr, name)
         bv.define_user_symbol(symbol)
-        # Optionally, define the data variable type
+
+        # Binary Ninja likely mis-interpreted instructions(functions) at data_addr after linear sweep.
+        try:
+            rem_func = self.bv.get_functions_containing(addr)
+            self.bv.remove_function(rem_func[0])
+        except:
+            log_info(f"No function to remove at addr: {hex(addr)}")
         bv.define_data_var(addr, Type.int(4, sign=False))
 
     #There has to be a better pythonic way of doing this.
@@ -483,6 +511,17 @@ class VitaElf():
             s += c
             addr += 1
         return s.decode("ascii", errors="ignore")
+
+    def clean_data_segs(self):
+        '''
+        With the last Linear Sweep run, Binary Ninja mis identifies lots of data segments past import_end as instructions(functions)
+        This will remove/undefine those functions.
+        '''
+        end_imports = self.base_addr + self.import_end
+        funcs = self.bv.functions
+        for func in funcs:
+            if func.start > end_imports:
+                self.bv.remove_function(func)
 
 
 def sweep_before_load(bv):
@@ -512,14 +551,14 @@ def sweep_before_load(bv):
             i += 1
 
         if i >= n_max:
-            log_info("ran {i} linear sweeps, potentially more functions undiscovered")
+            log_info(f"ran {i} linear sweeps, potentially more functions undiscovered")
 
         #Switch back to main UI event thread and run plugin
         execute_on_main_thread(lambda: VitaElf(bv).load_vita_symbols())
 
     #Run linear sweep analysis in new thread.
     threading.Thread(target=n_linearsweep).start()
-    
+
 def register_plugin():
     #register plugin after the ARMv7 BinaryView is loaded.
 
@@ -530,3 +569,4 @@ def register_plugin():
     )
 
 register_plugin()
+


### PR DESCRIPTION
- Adding structs for each imported module, stub, and entry.
- Remove misidentified instructions(functions) created where modules or data should be - currently only covers addresses past `stub_end` and at locations of identified variables, modules, stubs, or entrys.
 