### PR TITLE
Adding optional(experimental) cleaning feature 

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,8 +1,23 @@
-from .vita_loader import sweep_before_load
-from binaryninja import PluginCommand
+from .vita_loader import sweep_before_load, attempt_additional_cleaning
+from binaryninja import PluginCommand, BinaryView
+
+def is_symbols_injected(bv: BinaryView) -> bool:
+    """
+    Check persistant(.bndb) faux `VitaELF_Injected` symbol.
+    This prevents running additional optional features until symbols have been injected.
+    """
+    return bv.get_symbol_by_raw_name("VitaELF_Injected") is not None
+
 
 PluginCommand.register(
-    "VitaELF: Inject Symbols",
+    "PSVitaLoader\\1. VitaELF: Inject Symbols",
     "Injects resolved NID symbols into the ARMv7 BinaryView.",
     sweep_before_load
+)
+
+PluginCommand.register(
+    "PSVitaLoader\[Experimental] Attempt Additional Cleaning",
+    "Likely to give better results, removes non t2(base instruction) functions, re-runs linsweep, then removes any mis-identified functions where known data/variables exists.",
+    attempt_additional_cleaning,
+    is_symbols_injected
 )


### PR DESCRIPTION
Automates the solution in notes, overall end result improves decompilation of binary substantially in most cases. 

In most cases, this tends to correct for:
        - Aggressive number of linear sweeps overwriting data segments.
        - Missing functions or bad instructions(Typically when a function containing blx is not caught and BN attempts to analyze 4B Thumb2 instructions as 2-2Byte ArmV7 instructions and vice-versa).